### PR TITLE
Lumin OS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+.node-gyp

--- a/binding.gyp
+++ b/binding.gyp
@@ -18,10 +18,13 @@
           ],
           'defines': ['HAVE_CONFIG_H'],
         }],
-     	['OS=="android"', {
-	      "cflags_cc":["-fPIC"],
-	      "defines": ["ANDROID"],
-	    }],
+        ['LUMIN=="true"', {
+          'defines': ['LUMIN'],
+        }],
+        ['OS=="android"', {
+          "cflags_cc":["-fPIC"],
+          "defines": ["ANDROID"],
+        }],
       ],
     }
   ]

--- a/main.cpp
+++ b/main.cpp
@@ -312,10 +312,10 @@ inline int Start(Thread *thread,
 }
 
 static void *threadFn(void *arg) {
-  #ifndef ANDROID
+#if !defined(ANDROID) && !defined(LUMIN)
   pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, nullptr);
   pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, nullptr);
-  #endif
+#endif
 
   Thread *thread = (Thread *)arg;
   Thread::setCurrentThread(thread);
@@ -664,9 +664,10 @@ NAN_METHOD(Thread::Cancel) {
   Thread *thread = ObjectWrap::Unwrap<Thread>(info.This());
 
   // forcefully cancel thread
-  #ifndef ANDROID
+#if !defined(ANDROID) && !defined(LUMIN)
   pthread_cancel(thread->getThread());
-  #endif
+#endif
+
   // wait for thread to exit
   // pthread_join(thread->getThread(), nullptr);
 


### PR DESCRIPTION
This adds support for the `--LUMIN=true` flag to npm install, to allow for elision of incompatible `pthread` code similar to the `ANDROID` case.